### PR TITLE
Add numa lib and UMD device api dir

### DIFF
--- a/sources/sample_lib/CMakeLists.txt
+++ b/sources/sample_lib/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(sample_lib PUBLIC
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/wormhole
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/wormhole/wormhole_b0_defines
     $ENV{TT_METAL_HOME}/tt_metal/hw/inc/
+    $ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device/api/
     $ENV{TT_METAL_HOME}/tt_metal/third_party/umd/src/firmware/riscv/wormhole
     $ENV{TT_METAL_HOME}/tt_metal/third_party/umd/device
     $ENV{TT_METAL_HOME}/.cpmcache/fmt/73b5ec45edbd92babfd91c3777a9e1ab9cac8238/include
@@ -70,9 +71,9 @@ target_link_libraries(sample_lib PUBLIC
     tt_metal
     pthread
     Python::Python
+    numa
     $ENV{TT_METAL_HOME}/build/lib/_ttnn.so
     $ENV{TT_METAL_HOME}/build/lib/libdevice.so
-    $ENV{TT_METAL_HOME}/build/lib/libfmt.so
     $ENV{TT_METAL_HOME}/build/lib/libnng.so.1
 )
 


### PR DESCRIPTION
### Problem description
- libfmt.so doesn't exist anymore after building TT-Metal
- Numalib is required
- UMD device api dir is required now otherwise it would produce this error:
```
/home/jush/tt-metal/tt_metal/common/tt_backend_api_types.hpp:15:10: fatal error: 'umd/device/tt_arch_types.h' file not found
   15 | #include "umd/device/tt_arch_types.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

### What's changed
- Removed libfmt.so and added numa into link libs
- Add UMD device api directory into target includes
